### PR TITLE
longqc rule + pipeline-core.yaml changes

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -63,6 +63,7 @@ def get_chromosomes(wildcards):
 """ RULE FILES """
 include: "rules/gather.smk"
 include: "rules/pipeline-core.smk"
+include: "rules/qc.smk"
 
 
 rule all:
@@ -83,6 +84,7 @@ rule all:
         expand(OUTPUT_PATH + "mapping/by_chrom/{chrom}.bam", chrom=chromosomes),
         expand(OUTPUT_PATH + "counts/{chrom}.counts.h5ad", chrom=chromosomes),
         OUTPUT_PATH + 'anndata/anndata.raw.h5ad',
+        expand(OUTPUT_PATH + "qc/longqc/{sid}/summary.txt", sid=samples),
 
 
 

--- a/envs/pipeline-core.yaml
+++ b/envs/pipeline-core.yaml
@@ -12,3 +12,7 @@ dependencies:
   - seqkit 
   - blaze2
   - htseq
+  - longqc
+  - matplotlib
+  - scipy
+  - biopython

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -1,0 +1,22 @@
+rule longqc_ont:
+    """
+    Performs quality control (QC) on ONT sequencing data using LongQC.
+    Runs LongQC in ONT mode to generate quality control statistics 
+    for each sample’s raw FASTQ file.
+    """
+    input:
+        fastq=OUTPUT_PATH + "fastq/{sid}" + extension
+    output:
+        report_dir=directory(OUTPUT_PATH + "qc/longqc/{sid}/"),
+        summary=OUTPUT_PATH + "qc/longqc/{sid}/summary.txt"
+    wildcard_constraints:
+        sid='|'.join([re.escape(x) for x in set(samples)])
+    threads:
+        config['threads'] // 4
+    conda:
+        "pipeline-core"
+    shell:
+        """
+        longQC.py sampleqc -x ont -s {wildcards.sid} -o {output.report_dir} {input.fastq}
+        mv {output.report_dir}/summary.txt {output.summary}
+        """


### PR DESCRIPTION
Added rule for longQC analysis for ONT data. Applicable dependencies added to pipeline-core.yaml (could make a third env). Have not added to rule all yet, but could add once minimal working example is verified.